### PR TITLE
if unique_id starts with a slash, remove it

### DIFF
--- a/soundcloud-downloader.py
+++ b/soundcloud-downloader.py
@@ -31,6 +31,8 @@ def get_profile_tracks(tracks_url):
 
 def get_download_link(waveform_url):
     unique_id = waveform_url[21:][:-6]
+    if unique_id.startswith('/'):
+        unique_id = unique_id[1:]
     return 'http://media.soundcloud.com/stream/{}'.format(unique_id)
 
 


### PR DESCRIPTION
At least for https://soundcloud.com/robyn, the unique_id in get_download_link(waveform_url) starts with a slash, wich lead to 404 errors. As the unique_id for other songs may be without slash, check for it before removing.
